### PR TITLE
Fix typing annoyance of send/sendAndWaitForReceipt

### DIFF
--- a/packages/contractkit/src/wrappers/BaseWrapper.ts
+++ b/packages/contractkit/src/wrappers/BaseWrapper.ts
@@ -247,11 +247,11 @@ export class CeloTransactionObject<O> {
   ) {}
 
   /** send the transaction to the chain */
-  send = (params?: CeloTransactionParams): Promise<TransactionResult> => {
+  send = (params?: Partial<CeloTransactionParams>): Promise<TransactionResult> => {
     return this.kit.sendTransactionObject(this.txo, { ...this.defaultParams, ...params })
   }
 
   /** send the transaction and waits for the receipt */
-  sendAndWaitForReceipt = (params?: CeloTransactionParams): Promise<TransactionReceipt> =>
+  sendAndWaitForReceipt = (params?: Partial<CeloTransactionParams>): Promise<TransactionReceipt> =>
     this.send(params).then((result) => result.waitReceipt())
 }


### PR DESCRIPTION
### Description

Functions clearly accept partial parameters, but they are mistyped right now. Making it really annoying having to write code like this:
```
txo.sendAndWaitForReceipt({from: XXX} as any)
```
There should be no need to type cast to any, it should just be typed correctly to begin with.

### Other changes

None

### Tested

Will test with a pull request draft. 

### Related issues

N/A

### Backwards compatibility

This makes type more flexible so it should be fully backwards compatible. 